### PR TITLE
Cache bust service worker

### DIFF
--- a/services/app/src/js/constants/index.ts
+++ b/services/app/src/js/constants/index.ts
@@ -1,5 +1,5 @@
 // The URL where the service worker exists.
-const serviceWorkerUrl = './service-worker.js';
+const serviceWorkerUrl = './service-worker.js?cache-buster=1';
 
 export { serviceWorkerUrl };
 export { default as pushPublicKey } from './pushPublicKey';


### PR DESCRIPTION
Something somewhere is caching the service worker. I'm adding this query parameter to get around it.