### PR TITLE
Try fix app docker image

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -16,7 +16,7 @@ services:
     github:
       branch: 'main'
       deploy_on_push: true
-      repo: 'tix-factory/push-notifications-demo'
+      repo: 'tix-factory/push-notifications'
     health_check:
       http_path: '/health'
     http_port: 80
@@ -34,7 +34,7 @@ static_sites:
     github:
       branch: 'main'
       deploy_on_push: true
-      repo: 'tix-factory/push-notifications-demo'
+      repo: 'tix-factory/push-notifications'
     source_dir: 'services/app'
     output_dir: 'build'
     build_command: 'npm run build'

--- a/libs/js/push-notifications/package-lock.json
+++ b/libs/js/push-notifications/package-lock.json
@@ -7,23 +7,25 @@
     "": {
       "name": "@tix-factory/push-notifications",
       "version": "1.0.0",
-      "dependencies": {
-        "@types/react": "^18.0.28",
-        "react": "^18.2.0"
-      },
       "devDependencies": {
         "typescript": "^5.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.0.28",
+        "react": "^18.2.0"
       }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "peer": true
     },
     "node_modules/@types/react": {
       "version": "18.0.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
       "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -33,22 +35,26 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "peer": true
     },
     "node_modules/csstype": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
+      "peer": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -60,6 +66,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -85,12 +92,14 @@
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "peer": true
     },
     "@types/react": {
       "version": "18.0.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
       "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
+      "peer": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -100,22 +109,26 @@
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "peer": true
     },
     "csstype": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
+      "peer": true
     },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
     },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -124,6 +137,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }

--- a/libs/js/push-notifications/package.json
+++ b/libs/js/push-notifications/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@types/react": "^18.0.28",
     "react": "^18.2.0"
   },

--- a/services/api/Directory.Build.props
+++ b/services/api/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup Label="AssemblyMetadata">
     <Company>Tix Factory</Company>
-    <RepositoryUrl>https://github.com/tix-factory/push-notifications-demo</RepositoryUrl>
+    <RepositoryUrl>https://github.com/tix-factory/push-notifications</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 

--- a/services/api/src/Controllers/PushNotificationsController.cs
+++ b/services/api/src/Controllers/PushNotificationsController.cs
@@ -161,7 +161,7 @@ public class PushNotificationsController : Controller
             Title = "Hello, world!",
             Message = "This notification was sent using the push API.",
             Link = new Uri("https://demo.push-notifications.app?notification_clicked=true"),
-            ButtonLink = new Uri("https://github.com/tix-factory/push-notifications-demo/issues"),
+            ButtonLink = new Uri("https://github.com/tix-factory/push-notifications/issues"),
             Icon = new Uri("https://cdn.jsdelivr.net/gh/twitter/twemoji@v14.0.2/assets/72x72/1f514.png")
         };
 

--- a/services/app/Dockerfile
+++ b/services/app/Dockerfile
@@ -1,19 +1,26 @@
 # Setup runtime images
 FROM node:19 AS base
 
-# Setup build image
-FROM node:19 AS build
+# Setup image to build the published module with
+FROM node:19 AS build-module
 
-# Copy files over
-COPY ./services/app ./services/app
+# Copy the files over
 COPY ./libs/js ./libs/js
 
-# Install the module packages
+# Install the packages
 WORKDIR /libs/js/push-notifications
 RUN npm ci
 
 # Build the module
 RUN npm run build
+
+# Setup build image
+FROM node:19 AS build
+
+# Copy files over
+COPY --from=build-module /libs/js/push-notifications/dist /libs/js/push-notifications/dist
+COPY --from=build-module /libs/js/push-notifications/package.json /libs/js/push-notifications/package.json
+COPY ./services/app ./services/app
 
 # Install the packages
 WORKDIR /services/app

--- a/services/app/package-lock.json
+++ b/services/app/package-lock.json
@@ -26,12 +26,12 @@
     "../../libs/js/push-notifications": {
       "name": "@tix-factory/push-notifications",
       "version": "1.0.0",
-      "dependencies": {
-        "@types/react": "^18.0.28",
-        "react": "^18.2.0"
-      },
       "devDependencies": {
         "typescript": "^5.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.0.28",
+        "react": "^18.2.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -21133,8 +21133,6 @@
     "@tix-factory/push-notifications": {
       "version": "file:../../libs/js/push-notifications",
       "requires": {
-        "@types/react": "^18.0.28",
-        "react": "^18.2.0",
         "typescript": "^5.0.2"
       }
     },


### PR DESCRIPTION
# What :hammer:

Definitely should have tested this before committing #11. Apparently the `file` versioning for the `package.json` file uses `npm link`, which copies over the `node_modules` from the library, and then causes mass destruction.
See also: https://github.com/facebook/react/issues/24928#issuecomment-1257811965

# Fix :package:

To fix the docker image, and allow us to use the local module, we can build the module separate from app itself, and then copy over (exclusively) the distributable files into the `app` build image.

# Unrelated :label:

I also removed some references that referred to this repository with the `-demo` suffix, since we renamed the repository to.. no longer have that suffix.

# Broken :see_no_evil:

Still broken is the ability to run the app via Visual Studio code, because the `npm link` call breaks the app as-is.