### PR TITLE
Generate VAPID keys dynamically

### DIFF
--- a/.github/workflows/push-notifications-demo.yml
+++ b/.github/workflows/push-notifications-demo.yml
@@ -34,10 +34,12 @@ jobs:
         run: |
           docker-compose up -d
           sleep 5
+        env:
+          VAPID__EMAIL_ADDRESS: 'example@example.com'
 
       - name: '🔌 Ensure Connectivity (api)'
         run: >-
-          curl -v --fail http://localhost:${{ env.PUSH_NOTIFICATIONS_API_PORT }}/health
+          curl -v --fail http://localhost:${{ env.PUSH_NOTIFICATIONS_API_PORT }}/api/v1/push-notifications/metadata
 
       - name: '🔌 Ensure Connectivity (app)'
         run: >-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - '${PUSH_NOTIFICATIONS_API_PORT:-}:80'
 
-    env:
+    environment:
       - 'VAPID__EMAIL_ADDRESS=${VAPID__EMAIL_ADDRESS:-}'
 
     restart: 'always'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,9 @@ services:
     ports:
       - '${PUSH_NOTIFICATIONS_API_PORT:-}:80'
 
+    env:
+      - 'VAPID__EMAIL_ADDRESS=${VAPID__EMAIL_ADDRESS:-}'
+
     restart: 'always'
 
   app:

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -8,17 +8,11 @@ This is a demo project, the authententication mechanism is not setup to share ke
 
 ## :gear: Configuration
 
-The [appsettings.json](./src/appsettings.json#L12) contains the `PUBLIC_KEY`, which also exists in [pushPublicKey.ts](../app/src/js/constants//pushPublicKey.ts).
+The `VAPID__EMAIL_ADDRESS` environment variable must be set, and is sent to the browser push notification server, as a form of voluntary authentication. It can be used to contact the server owner if needed.
 
-When you run this application you must also have a `PRIVATE_KEY` and `EMAIL_ADDRESS` set in the `VAPID` configuration section.
+Additionally, we will need a `VAPID__PUBLIC_KEY` and `VAPID__PRIVATE_KEY`. The `PRIVATE_KEY` must pair with the `PUBLIC_KEY`.
+If these configurations are not provided, they will be generated when the server starts.
 
-These can be injedcted with the following environment variables:
-
--   `VAPID__PRIVATE_KEY`
--   `VAPID__EMAIL_ADDRESS`
-
-The `PRIVATE_KEY` must pair with the `PUBLIC_KEY`. For the purposes of this demo, [web-push-codelab](https://web-push-codelab.glitch.me/) can be used to generate these keys.
-
-The `EMAIL_ADDRESS` is sent to the browser push notification server, as a form of voluntary authentication. It can be used to contact the server owner if needed.
+[web-push-codelab](https://web-push-codelab.glitch.me/) is a helpful site that can be used to generate these keys.
 
 See more on `VAPID`: [Sending VAPID identified web push notifications](https://blog.mozilla.org/services/2016/08/23/sending-vapid-identified-webpush-notifications-via-mozillas-push-service/)

--- a/services/api/src/Models/MetadataResult.cs
+++ b/services/api/src/Models/MetadataResult.cs
@@ -1,0 +1,19 @@
+using System.Runtime.Serialization;
+
+namespace TixFactory.PushNotifications.Api;
+
+/// <summary>
+/// Metadata about the push notifications for this server.
+/// </summary>
+[DataContract]
+public class MetadataResult
+{
+    /// <summary>
+    /// The base64 encoded public key for the push subscription.
+    /// </summary>
+    /// <remarks>
+    /// This is intended to be the base64 encoded value for the <see href="https://developer.mozilla.org/en-US/docs/Web/API/PushManager/subscribe">PushManager.subscribe</see> applicationServerKey.
+    /// </remarks>
+    [DataMember(Name = "publicKey")]
+    public string PublicKey { get; set; }
+}

--- a/services/api/src/Models/VapidConfiguration.cs
+++ b/services/api/src/Models/VapidConfiguration.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Configuration;
+
+namespace TixFactory.PushNotifications.Api;
+
+/// <summary>
+/// The VAPID configuration for the application.
+/// </summary>
+/// <remarks>
+/// VAPID details are used to identify ourselves with the push notification server.
+/// We must have a public key, private key, and email address.
+/// </remarks>
+/// <seealso href="https://blog.mozilla.org/services/2016/08/23/sending-vapid-identified-webpush-notifications-via-mozillas-push-service/"/>
+public class VapidConfiguration
+{
+    /// <summary>
+    /// The base64 encoded VAPID public key.
+    /// </summary>
+    [ConfigurationKeyName("PUBLIC_KEY")]
+    public string PublicKey { get; set; }
+
+    /// <summary>
+    /// The base64 encoded VAPID private key.
+    /// </summary>
+    /// <remarks>
+    /// Pairs with the public key.
+    /// </remarks>
+    [ConfigurationKeyName("PRIVATE_KEY")]
+    public string PrivateKey { get; set; }
+
+    /// <summary>
+    /// The VAPID email address.
+    /// </summary>
+    [ConfigurationKeyName("EMAIL_ADDRESS")]
+    public string EmailAddress { get; set; }
+}

--- a/services/api/src/appsettings.json
+++ b/services/api/src/appsettings.json
@@ -7,8 +7,5 @@
   },
   "PushNotifications": {
     "TimeToLive": "01:00:00" 
-  },
-  "VAPID": {
-    "PUBLIC_KEY": "BPMX2ZD3jlIqKZOa8HhAVI2m_Ve_TyQK_opikVeg3v59U0UGTwVrNh9j4pPkMrs5ev5C_GnE6pJwpgASMhGCPWc"
   }
 }

--- a/services/app/src/js/constants/index.ts
+++ b/services/app/src/js/constants/index.ts
@@ -2,4 +2,3 @@
 const serviceWorkerUrl = './service-worker.js?cache-buster=1';
 
 export { serviceWorkerUrl };
-export { default as pushPublicKey } from './pushPublicKey';

--- a/services/app/src/js/constants/pushPublicKey.ts
+++ b/services/app/src/js/constants/pushPublicKey.ts
@@ -1,7 +1,0 @@
-import { translatePublicKey } from '@tix-factory/push-notifications';
-
-// Generated here: https://web-push-codelab.glitch.me/
-const publicKey =
-  'BPMX2ZD3jlIqKZOa8HhAVI2m_Ve_TyQK_opikVeg3v59U0UGTwVrNh9j4pPkMrs5ev5C_GnE6pJwpgASMhGCPWc';
-
-export default translatePublicKey(publicKey);

--- a/services/app/src/js/react/components/send-notification-button/index.tsx
+++ b/services/app/src/js/react/components/send-notification-button/index.tsx
@@ -9,9 +9,16 @@ import {
 import NotificationSendStatus from '../../../enums/notificationSendStatus';
 import ServerRegistrationState from '../../../enums/serverRegistrationState';
 import { register, sendPushNotification } from '../../../services/api';
-import { pushPublicKey, serviceWorkerUrl } from '../../../constants';
+import { serviceWorkerUrl } from '../../../constants';
 
-export default function SendNotificationButton() {
+type SendNotificationButtonInput = {
+  // The public key to create the push subscription with.
+  pushPublicKey: Uint8Array;
+};
+
+export default function SendNotificationButton({
+  pushPublicKey,
+}: SendNotificationButtonInput) {
   const [notificationPermission, requestNotificationPermission] =
     useNotificationPermission();
   const [pushSubscription, pushSubscriptionState] =

--- a/services/app/src/js/services/api.ts
+++ b/services/app/src/js/services/api.ts
@@ -1,6 +1,10 @@
-import { serializePushSubscription } from '@tix-factory/push-notifications';
+import {
+  serializePushSubscription,
+  translatePublicKey,
+} from '@tix-factory/push-notifications';
 
 let registeredEndpoints: { [endpoint: string]: Date } = {};
+let publicKey: Uint8Array | null = null;
 
 const register = async (pushSubscription: PushSubscription): Promise<void> => {
   const serializedPushSubscription = await serializePushSubscription(
@@ -43,4 +47,18 @@ const sendPushNotification = async (): Promise<void> => {
   }
 };
 
-export { register, sendPushNotification };
+const loadPublicKey = async (): Promise<Uint8Array> => {
+  if (publicKey) {
+    return Promise.resolve(publicKey);
+  }
+
+  const response = await fetch('/api/v1/push-notifications/metadata');
+  if (!response.ok) {
+    throw new Error('Failed to load push notifications public key.');
+  }
+
+  const result = await response.json();
+  return (publicKey = translatePublicKey(result.publicKey));
+};
+
+export { register, loadPublicKey, sendPushNotification };


### PR DESCRIPTION
# What :key:

This review will ensure that if the VAPID public and private keys are not set when the application starts, they will be generated.

This review also will load the public key from the server on the app side, rather than hard coding the key in the app. This allows the app to adapt to what the server knows to be the public key.